### PR TITLE
Fix checkout config

### DIFF
--- a/Model/CredovaPaymentConfigProvider.php
+++ b/Model/CredovaPaymentConfigProvider.php
@@ -95,7 +95,8 @@ class CredovaPaymentConfigProvider implements \Magento\Checkout\Model\ConfigProv
         return [
             'credova' => [
                 'store' => $this->credovaConfig->getCredovaStoreCode(),
-                'environment' => $this->credovaConfig->getCredovaEnvironment()
+                'environment' => $this->credovaConfig->getCredovaEnvironment(),
+                'minimumAmount' => $this->credovaConfig->getCredovaMinimumAmount()
             ]
         ];
     }

--- a/Model/CredovaPaymentConfigProvider.php
+++ b/Model/CredovaPaymentConfigProvider.php
@@ -93,7 +93,10 @@ class CredovaPaymentConfigProvider implements \Magento\Checkout\Model\ConfigProv
     public function getConfig()
     {
         return [
-            // 'key' => 'value' pairs of configuration
+            'credova' => [
+                'store' => $this->credovaConfig->getCredovaStoreCode(),
+                'environment' => $this->credovaConfig->getCredovaEnvironment()
+            ]
         ];
     }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -34,13 +34,6 @@
         </arguments>
     </type>
 
-    <type name="Magento\Checkout\Model\CompositeConfigProvider">
-        <arguments>
-            <argument name="configProviders" xsi:type="array">
-                <item name="credova" xsi:type="object">ClassyLlama\Credova\Model\CredovaPaymentConfigProvider</item>
-            </argument>
-        </arguments>
-    </type>
 
     <preference for="ClassyLlama\Credova\Api\Data\ApplicationInfoInterface" type="ClassyLlama\Credova\Model\Data\Application"/>
     <preference for="ClassyLlama\Credova\Api\Data\FederalLicenseInterface" type="ClassyLlama\Credova\Model\Data\FederalLicense"/>

--- a/etc/frontend/di.xml
+++ b/etc/frontend/di.xml
@@ -13,4 +13,12 @@
             </argument>
         </arguments>
     </type>
+
+    <type name="Magento\Checkout\Model\CompositeConfigProvider">
+        <arguments>
+            <argument name="configProviders" xsi:type="array">
+                <item name="credova" xsi:type="object">ClassyLlama\Credova\Model\CredovaPaymentConfigProvider</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/view/frontend/web/js/view/payment/method-renderer/credova.js
+++ b/view/frontend/web/js/view/payment/method-renderer/credova.js
@@ -25,9 +25,10 @@ export default Component.extend({
         this.applicationRequestProcessing = false;
         this.observe(['publicId', 'applicationRequestProcessing']);
 
+        var environmentName = window.checkoutConfig.credova.environment;
         window.CRDV.plugin.config({
-            environment: window.CRDV.Environment.Sandbox,
-            store: "CLL000"
+            environment: window.CRDV.Environment[environmentName],
+            store: window.checkoutConfig.credova.store
         });
 
         window.CRDV.plugin.addEventListener(this.onCredovaEvent.bind(this));

--- a/view/frontend/web/js/view/payment/method-renderer/credova.js
+++ b/view/frontend/web/js/view/payment/method-renderer/credova.js
@@ -52,7 +52,7 @@ export default Component.extend({
 
     /** Returns is method available */
     isAvailable() {
-        return quote.totals()['grand_total'] >= 300;
+        return quote.totals()['grand_total'] >= window.checkoutConfig.credova.minimumAmount;
     },
 
     getData() {


### PR DESCRIPTION
There are a number of hardcoded test values in the payment method renderer. This PR uses the appropriate Magento CheckoutConfigProvider convention to supply the admin-configured values to the frontend.